### PR TITLE
Improvement for AbstractRepoTest.setSiteContentBase

### DIFF
--- a/src/main/java/nl/openweb/hippo/AbstractRepoTest.java
+++ b/src/main/java/nl/openweb/hippo/AbstractRepoTest.java
@@ -27,6 +27,7 @@ import java.io.PrintStream;
 import java.util.HashMap;
 import java.util.LinkedList;
 
+import org.apache.commons.lang.StringUtils;
 import org.hippoecm.hst.component.support.spring.util.MetadataReaderClasspathResourceScanner;
 import org.hippoecm.hst.content.beans.ObjectBeanManagerException;
 import org.hippoecm.hst.content.beans.manager.ObjectBeanManager;
@@ -88,10 +89,19 @@ public abstract class AbstractRepoTest extends SimpleHippoTest {
         requestContext.setContentBean(getHippoBean(path));
     }
 
+    /**
+     * Set the SiteContentBasePath and the siteContentBaseBean on HstRequestContext
+     * @param path absolute path. It must not be null or empty and it must start with a /
+     */
     protected void setSiteContentBase(String path) {
+        if (StringUtils.isBlank(path) || !path.startsWith("/")) {
+            throw new IllegalArgumentException("Parameter path must be a String that starts with /");
+        }
         try {
+            // here it must be absolute
             HippoBean hippoBean = (HippoBean) requestContext.getObjectBeanManager().getObject(path);
-            requestContext.setSiteContentBasePath(path);
+            // here it must be relative to root
+            requestContext.setSiteContentBasePath(path.substring(1));
             requestContext.setSiteContentBaseBean(hippoBean);
         } catch (ObjectBeanManagerException e) {
             throw new HstComponentException(e);

--- a/src/test/java/nl/openweb/hippo/BaseHippoTestTest.java
+++ b/src/test/java/nl/openweb/hippo/BaseHippoTestTest.java
@@ -28,7 +28,9 @@ import org.apache.commons.io.IOUtils;
 import org.hippoecm.hst.content.beans.query.HstQuery;
 import org.hippoecm.hst.content.beans.query.builder.HstQueryBuilder;
 import org.hippoecm.hst.content.beans.query.exceptions.QueryException;
+import org.hippoecm.hst.content.beans.standard.HippoBean;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -141,15 +143,40 @@ public class BaseHippoTestTest extends BaseHippoTest {
                     , UTF_8);
 
             String actualValue = new String(os.toByteArray(), UTF_8);
-            String osIndependentValue = actualValue.replace("\r\n", "\n").replace('\r', '\n');
-            assertEquals(expectedValue, osIndependentValue);
+
+            assertEquals(getOsIndependantValue(expectedValue), getOsIndependantValue(actualValue));
         }
+    }
+
+    private String getOsIndependantValue(String value) {
+        return value.replace("\r\n", "\n").replace('\r', '\n');
     }
 
     @Test
     public void hippoMirrorTest() {
         NewsPage hippoBean = (NewsPage) getHippoBean("/content/documents/mychannel/news/news3");
         assertEquals("news2", hippoBean.getRelatedNews().getName());
+    }
+
+
+    @Test(expected = IllegalArgumentException.class)
+    public void setSiteContentBaseTestNull() {
+        setSiteContentBase(null);
+        Assert.fail("Expected a IllegalArgumentException");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void setSiteContentBaseTestRelative() {
+        setSiteContentBase("a/b");
+        Assert.fail("Expected a IllegalArgumentException");
+    }
+
+    @Test
+    public void setSiteContentBaseTestAbsolute() {
+        setSiteContentBase("/content/documents/mychannel/news/news3");
+        Assert.assertEquals("content/documents/mychannel/news/news3", requestContext.getSiteContentBasePath());
+        HippoBean siteContentBaseBean = requestContext.getSiteContentBaseBean();
+        Assert.assertEquals("news3", siteContentBaseBean.getName());
     }
 
     @After


### PR DESCRIPTION
Fixed a bug in AbstractRepoTest.setSiteContentBase, added unittest for that. Also fixed a unittest that failed on my Windows machine.