### PR TITLE
V12support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.onehippo.cms7</groupId>
     <artifactId>hippo-cms7-release</artifactId>
-    <version>11.2.1</version>
+    <version>12.5.0</version>
   </parent>
 
   <groupId>nl.openweb.hippo</groupId>
   <artifactId>hippo-unit-tester</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.3.0-SNAPSHOT</version>
 
   <name>Hippo Unit Tester</name>
   <description>Hippo Unit Tester is framework aimed at simplifying unit testing of Hippo CMS</description>
@@ -49,6 +49,8 @@
   </developers>
 
   <properties>
+    <jcr-mocking-tool.version>1.4.0-SNAPSHOT</jcr-mocking-tool.version>
+
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
@@ -95,7 +97,7 @@
     <dependency>
       <groupId>nl.openweb.jcr</groupId>
       <artifactId>jcr-mocking-tool</artifactId>
-      <version>1.3.3</version>
+      <version>${jcr-mocking-tool.version}</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/nl/openweb/hippo/BaseHippoTest.java
+++ b/src/main/java/nl/openweb/hippo/BaseHippoTest.java
@@ -95,6 +95,15 @@ public abstract class BaseHippoTest extends AbstractRepoTest {
         return importer;
     }
 
+    protected void importResources(String path, String intermediateNodeType, String... pathsToResources) {
+        if (pathsToResources != null) {
+            for (String resource : pathsToResources) {
+                String format = getFileFormatByPath(resource);
+                getImporter(format).createNodes(getResourceAsStream(resource), path, intermediateNodeType);
+            }
+        }
+    }
+
     @Override
     public void teardown() {
         super.teardown();

--- a/src/main/java/nl/openweb/hippo/BaseHippoTest.java
+++ b/src/main/java/nl/openweb/hippo/BaseHippoTest.java
@@ -15,14 +15,15 @@
  */
 package nl.openweb.hippo;
 
-import javax.jcr.Credentials;
-import javax.jcr.Repository;
-import javax.jcr.Session;
-import javax.jcr.SimpleCredentials;
-
 import nl.openweb.hippo.exception.SetupTeardownException;
-import nl.openweb.jcr.Importer;
+import nl.openweb.hippo.importer.YamlImporter;
 import nl.openweb.jcr.InMemoryJcrRepository;
+import nl.openweb.jcr.importer.JcrImporter;
+import nl.openweb.jcr.importer.JsonImporter;
+import nl.openweb.jcr.importer.XmlImporter;
+
+import javax.jcr.*;
+import java.io.IOException;
 
 /**
  * @author Ebrahim Aharpour
@@ -33,8 +34,11 @@ public abstract class BaseHippoTest extends AbstractRepoTest {
     public static final SimpleCredentials ADMIN = new SimpleCredentials("admin", "admin".toCharArray());
     private InMemoryJcrRepository repository;
 
+
     @Override
     public void setup() {
+        repository = createRepository();
+        rootNode = getRootNode();
         super.setup();
         componentManager.addComponent(Repository.class.getName(), repository);
         componentManager.addComponent(Credentials.class.getName() + ".hstconfigreader", getWritableCredentials());
@@ -44,26 +48,51 @@ public abstract class BaseHippoTest extends AbstractRepoTest {
         componentManager.addComponent(Credentials.class.getName() + ".writable", getWritableCredentials());
     }
 
+    protected InMemoryJcrRepository createRepository() {
+        try {
+            return new InMemoryJcrRepository();
+        } catch (RepositoryException| IOException e) {
+            throw new SetupTeardownException(e);
+        }
+    }
+
+    private Node getRootNode() {
+            try {
+                if (repository == null) {
+                    repository = createRepository();
+                }
+                Session session = repository.login(ADMIN);
+                return  session.getRootNode();
+            } catch (Exception e) {
+                throw new SetupTeardownException(e);
+            }
+    }
+
     protected Credentials getWritableCredentials() {
         return ADMIN;
     }
 
     @Override
-    protected Importer getImporter() {
-        try {
-            repository = new InMemoryJcrRepository();
-
-            return new Importer.Builder(() -> {
-                Session session = repository.login(ADMIN);
-                return session.getRootNode();
-            })
-                    .addUnknownTypes(true)
-                    .saveSession(true)
-                    .addUuid(true)
-                    .build();
-        } catch (Exception e) {
-            throw new SetupTeardownException(e);
+    protected JcrImporter getImporter(String fileFormat) {
+        JcrImporter importer;
+        switch (fileFormat) {
+            case JsonImporter.FORMAT:
+                importer = new JsonImporter(getRootNode());
+                break;
+            case XmlImporter.FORMAT:
+                importer = new XmlImporter(getRootNode());
+                break;
+            case YamlImporter.FORMAT:
+                importer = new YamlImporter(getRootNode());
+                break;
+            default:
+                throw new IllegalArgumentException("No importer for fileFormat: " + fileFormat);
         }
+        importer.addUnknownTypes(true)
+                .saveSession(true)
+                .addUuid(true);
+
+        return importer;
     }
 
     @Override

--- a/src/main/java/nl/openweb/hippo/BaseHippoTest.java
+++ b/src/main/java/nl/openweb/hippo/BaseHippoTest.java
@@ -75,6 +75,9 @@ public abstract class BaseHippoTest extends AbstractRepoTest {
     @Override
     protected JcrImporter getImporter(String fileFormat) {
         JcrImporter importer;
+        if (fileFormat == null) {
+            throw new IllegalArgumentException("fileFormat may not be null");
+        }
         switch (fileFormat) {
             case JsonImporter.FORMAT:
                 importer = new JsonImporter(getRootNode());

--- a/src/main/java/nl/openweb/hippo/importer/YamlImporter.java
+++ b/src/main/java/nl/openweb/hippo/importer/YamlImporter.java
@@ -1,0 +1,95 @@
+package nl.openweb.hippo.importer;
+
+import nl.openweb.jcr.importer.AbstractJcrImporter;
+import nl.openweb.jcr.utils.PathUtils;
+import org.onehippo.cm.engine.JcrContentProcessor;
+import org.onehippo.cm.model.definition.ActionType;
+import org.onehippo.cm.model.impl.GroupImpl;
+import org.onehippo.cm.model.impl.ModuleImpl;
+import org.onehippo.cm.model.impl.ProjectImpl;
+import org.onehippo.cm.model.impl.definition.ContentDefinitionImpl;
+import org.onehippo.cm.model.parser.ContentSourceParser;
+import org.onehippo.cm.model.source.ResourceInputProvider;
+import org.onehippo.cm.model.source.Source;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * @author Ivor
+ */
+public class YamlImporter extends AbstractJcrImporter {
+    private static final Logger LOG = LoggerFactory.getLogger(YamlImporter.class);
+    private static final JcrContentProcessor PROCESSOR = new JcrContentProcessor();
+    public static final String FORMAT = "yaml";
+
+    public YamlImporter(Node rootNode) {
+        super(rootNode);
+    }
+
+    @Override
+    public Node createNodes(String yaml, String path, String intermediateNodeType) {
+        return this.createNodes(new ByteArrayInputStream(yaml.getBytes()), path, intermediateNodeType);
+    }
+
+    @Override
+    public Node createNodes(InputStream inputStream, String path, String intermediateNodeType) {
+
+        try {
+            final ResourceInputProvider resourceInputProvider = new ResourceInputProvider() {
+                @Override
+                public boolean hasResource(final Source source, final String resourcePath) {
+                    return false;
+                }
+
+                @Override
+                public InputStream getResourceInputStream(final Source source, final String resourcePath) throws IOException {
+                    throw new IOException("Plain YAML import does not support links to resources");
+                }
+
+            };
+
+            Node node = createNode(getRootNode(), path, intermediateNodeType);
+            final ModuleImpl module = new ModuleImpl("import-module", new ProjectImpl("import-project", new GroupImpl("import-group")));
+            final ContentSourceParser sourceParser = new ContentSourceParser(resourceInputProvider);
+            sourceParser.parse(inputStream, "/import", "console.yaml", module);
+            final ContentDefinitionImpl contentDefinition = module.getContentSources().iterator().next().getContentDefinition();
+            PROCESSOR.importNode(contentDefinition.getNode(), node, ActionType.RELOAD);
+
+
+            if (isSaveSession()) {
+                node.getSession().save();
+            }
+            return node;
+        } catch (Exception e) {
+            throw new RuntimeException("Import failed", e);
+        }
+    }
+
+    private Node createNode(final Node rootNode, final String path, final String intermediateNodeType) {
+        Node result = rootNode;
+        if (path != null && !path.isEmpty()) {
+            String[] nodes = PathUtils.normalizePath(path).split("/");
+            List<String> pathSegments = Arrays.asList(nodes);
+            for(String segment: pathSegments){
+                try {
+                    if (result.hasNode(segment)) {
+                        result = result.getNode(segment);
+                    } else {
+                        result = result.addNode(segment, intermediateNodeType);
+                    }
+                } catch (RepositoryException e) {
+                    LOG.error("error while trying to create the node structure", e);
+                }
+            }
+        }
+        return result;
+    }
+}

--- a/src/main/java/nl/openweb/hippo/mock/MockHstLinkCreator.java
+++ b/src/main/java/nl/openweb/hippo/mock/MockHstLinkCreator.java
@@ -100,6 +100,11 @@ public class MockHstLinkCreator implements HstLinkCreator {
     }
 
     @Override
+    public HstLink create(Node node, Mount mount, boolean crossMount) {
+        return getMockLink(node);
+    }
+
+    @Override
     public HstLink create(Node node, Mount mount, HstSiteMapItem preferredItem, boolean fallback) {
         return getMockLink(node);
     }

--- a/src/main/java/nl/openweb/hippo/mock/MockMount.java
+++ b/src/main/java/nl/openweb/hippo/mock/MockMount.java
@@ -15,9 +15,6 @@
  */
 package nl.openweb.hippo.mock;
 
-import java.util.*;
-
-import org.hippoecm.hst.configuration.channel.Channel;
 import org.hippoecm.hst.configuration.channel.ChannelInfo;
 import org.hippoecm.hst.configuration.hosting.Mount;
 import org.hippoecm.hst.configuration.hosting.MutableMount;
@@ -25,7 +22,9 @@ import org.hippoecm.hst.configuration.hosting.VirtualHost;
 import org.hippoecm.hst.configuration.internal.ContextualizableMount;
 import org.hippoecm.hst.configuration.site.HstSite;
 import org.hippoecm.hst.core.request.HstSiteMapMatcher;
+import org.onehippo.cms7.services.hst.Channel;
 
+import java.util.*;
 /**
  * @author Ebrahim Aharpour
  * @since 6/19/2017
@@ -85,6 +84,10 @@ public class MockMount implements ContextualizableMount {
     private List<String> cmsLocations;
     private String type;
     private List<String> types;
+    private boolean noChannelInfo;
+    private boolean finalPipeline;
+    private boolean explicit;
+    private Map<String, String> responseHeaders = new HashMap<>();
 
     @Override
     public VirtualHost getVirtualHost() {
@@ -259,6 +262,16 @@ public class MockMount implements ContextualizableMount {
     }
 
     @Override
+    public Map<String, String> getResponseHeaders() {
+        return responseHeaders;
+    }
+
+    @Override
+    public boolean isExplicit() {
+        return explicit;
+    }
+
+    @Override
     public Channel getPreviewChannel() {
         return previewChannel;
     }
@@ -283,6 +296,12 @@ public class MockMount implements ContextualizableMount {
 
     public void setMountPoint(String mountPoint) {
         this.mountPoint = mountPoint;
+    }
+
+
+    @Override
+    public boolean hasNoChannelInfo() {
+        return noChannelInfo;
     }
 
     @Override
@@ -562,16 +581,19 @@ public class MockMount implements ContextualizableMount {
         this.channelPath = channelPath;
     }
 
-    @Override
     public void setChannelInfo(ChannelInfo info, ChannelInfo previewInfo) {
         this.channelInfo = info;
         this.previewChannelInfo = previewInfo;
     }
 
-    @Override
     public void setChannel(Channel channel, Channel previewChannel) {
         this.channel = channel;
         this.previewChannel = previewChannel;
+    }
+
+    @Override
+    public boolean isFinalPipeline() {
+        return finalPipeline;
     }
 
     @Override
@@ -609,5 +631,21 @@ public class MockMount implements ContextualizableMount {
     @Override
     public boolean isOfType(String type) {
         return types != null ? types.contains(type) : false;
+    }
+
+    public void setNoChannelInfo(final boolean noChannelInfo) {
+        this.noChannelInfo = noChannelInfo;
+    }
+
+    public void setFinalPipeline(final boolean finalPipeline) {
+        this.finalPipeline = finalPipeline;
+    }
+
+    public void setExplicit(final boolean explicit) {
+        this.explicit = explicit;
+    }
+
+    public void setResponseHeaders(final Map<String, String> responseHeaders) {
+        this.responseHeaders = responseHeaders;
     }
 }

--- a/src/test/java/nl/openweb/hippo/BaseHippoTestTest.java
+++ b/src/test/java/nl/openweb/hippo/BaseHippoTestTest.java
@@ -24,6 +24,7 @@ import org.hippoecm.hst.content.beans.query.HstQuery;
 import org.hippoecm.hst.content.beans.query.builder.HstQueryBuilder;
 import org.hippoecm.hst.content.beans.query.exceptions.QueryException;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -47,6 +48,33 @@ public class BaseHippoTestTest extends BaseHippoTest {
 
 
     private static final String COMPONENT_NAME = "myComponent";
+
+
+    @Test
+    public void testGetFileFormatByPathIsIgnoringCase() {
+        Assert.assertEquals("bar", getFileFormatByPath("foo.BAR"));
+        Assert.assertEquals("json", getFileFormatByPath("foo.Json"));
+        Assert.assertEquals("json", getFileFormatByPath("foo.JSON"));
+        Assert.assertEquals("json", getFileFormatByPath("foo.json"));
+        Assert.assertEquals("xml", getFileFormatByPath("foo.xml"));
+        Assert.assertEquals("xml", getFileFormatByPath("foo.XML"));
+    }
+    @Test
+    public void testGetFileFormatByPathHandlesFileWithoutExtension() {
+        Assert.assertNull(getFileFormatByPath(null));
+        Assert.assertNull(getFileFormatByPath("foo"));
+    }
+
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetImporterShouldThrowExceptionForUnknownFormat() {
+        getImporter("foo");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetImporterShouldThrowExceptionForNullFormat() {
+        getImporter(null);
+    }
 
     @Test
     public void testHstRequest() {

--- a/src/test/java/nl/openweb/hippo/BaseHippoTestTest.java
+++ b/src/test/java/nl/openweb/hippo/BaseHippoTestTest.java
@@ -16,14 +16,9 @@
 
 package nl.openweb.hippo;
 
-import javax.jcr.Node;
-import javax.jcr.Property;
-import javax.jcr.RepositoryException;
-import javax.jcr.Value;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.PrintStream;
-
+import nl.openweb.hippo.demo.domain.NewsPage;
+import nl.openweb.hippo.exception.SetupTeardownException;
+import nl.openweb.jcr.importer.XmlImporter;
 import org.apache.commons.io.IOUtils;
 import org.hippoecm.hst.content.beans.query.HstQuery;
 import org.hippoecm.hst.content.beans.query.builder.HstQueryBuilder;
@@ -32,9 +27,13 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import nl.openweb.hippo.demo.domain.NewsPage;
-import nl.openweb.hippo.exception.SetupTeardownException;
-
+import javax.jcr.Node;
+import javax.jcr.Property;
+import javax.jcr.RepositoryException;
+import javax.jcr.Value;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hippoecm.repository.api.HippoNodeType.HIPPO_PATHS;
@@ -124,7 +123,7 @@ public class BaseHippoTestTest extends BaseHippoTest {
         try {
             super.setup();
             registerNodeType("ns:NewsPage", "ns:AnotherType");
-            importer.createNodesFromXml(getResourceAsStream("/nl/openweb/hippo/demo/news.xml"),
+            getImporter(XmlImporter.FORMAT).createNodes(getResourceAsStream("/nl/openweb/hippo/demo/news.xml"),
                     "/content/documents/mychannel/news", "hippostd:folder");
         } catch (RepositoryException e) {
             throw new SetupTeardownException(e);
@@ -142,7 +141,8 @@ public class BaseHippoTestTest extends BaseHippoTest {
 
             String actualValue = new String(os.toByteArray(), UTF_8);
             String osIndependentValue = actualValue.replace("\r\n", "\n").replace('\r', '\n');
-            assertEquals(expectedValue, osIndependentValue);
+            String osIndependentExpectedValue = expectedValue.replace("\r\n", "\n").replace('\r', '\n');
+            assertEquals(osIndependentExpectedValue, osIndependentValue);
         }
     }
 

--- a/src/test/java/nl/openweb/hippo/HippoRepositrySpecificTests.java
+++ b/src/test/java/nl/openweb/hippo/HippoRepositrySpecificTests.java
@@ -16,12 +16,14 @@
 
 package nl.openweb.hippo;
 
-import javax.jcr.RepositoryException;
-
+import nl.openweb.jcr.importer.JcrImporter;
+import nl.openweb.jcr.importer.XmlImporter;
 import org.hippoecm.hst.content.beans.standard.HippoBean;
 import org.hippoecm.hst.content.beans.standard.HippoDocument;
 import org.hippoecm.hst.content.beans.standard.facetnavigation.HippoFacetNavigation;
 import org.junit.*;
+
+import javax.jcr.RepositoryException;
 
 /**
  * @author Ebrahim Aharpour
@@ -36,9 +38,10 @@ public class HippoRepositrySpecificTests extends BaseHippoTest {
         registerNodeType("ns:basedocument", "hippo:document");
         registerNodeType("ns:author", "ns:basedocument");
         registerNodeType("ns:blogpost", "ns:basedocument");
-        importer.createNodesFromXml(getResourceAsStream("/nl/openweb/hippo/blog.xml"),
+        JcrImporter importer = getImporter(XmlImporter.FORMAT);
+        importer.createNodes(getResourceAsStream("/nl/openweb/hippo/blog.xml"),
                 "/content/documents/mychannel/blog", "hippostd:folder");
-        importer.createNodesFromXml(getResourceAsStream("/nl/openweb/hippo/blogFacets.xml"),
+        importer.createNodes(getResourceAsStream("/nl/openweb/hippo/blogFacets.xml"),
                 "/content/documents/mychannel/blogFacets", "hippostd:folder");
         setSiteContentBase("/content/documents/mychannel");
 

--- a/src/test/java/nl/openweb/hippo/demo/EssentialsListComponentTest.java
+++ b/src/test/java/nl/openweb/hippo/demo/EssentialsListComponentTest.java
@@ -18,7 +18,6 @@ package nl.openweb.hippo.demo;
 import javax.jcr.RepositoryException;
 import java.util.List;
 
-import nl.openweb.jcr.importer.XmlImporter;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -52,8 +51,7 @@ public class EssentialsListComponentTest extends BaseHippoTest {
         try {
             super.setup();
             registerNodeType("ns:NewsPage", "ns:AnotherType");
-            getImporter(XmlImporter.FORMAT).createNodes(getResourceAsStream("news.xml"),
-                    "/content/documents/mychannel/news", "hippostd:folder");
+            importResources("/content/documents/mychannel/news", "hippostd:folder", "news.xml");
             recalculateHippoPaths();
             setSiteContentBase("/content/documents/mychannel");
             component.init(null, componentConfiguration);

--- a/src/test/java/nl/openweb/hippo/demo/EssentialsListComponentTest.java
+++ b/src/test/java/nl/openweb/hippo/demo/EssentialsListComponentTest.java
@@ -18,6 +18,7 @@ package nl.openweb.hippo.demo;
 import javax.jcr.RepositoryException;
 import java.util.List;
 
+import nl.openweb.jcr.importer.XmlImporter;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -51,7 +52,7 @@ public class EssentialsListComponentTest extends BaseHippoTest {
         try {
             super.setup();
             registerNodeType("ns:NewsPage", "ns:AnotherType");
-            importer.createNodesFromXml(getResourceAsStream("news.xml"),
+            getImporter(XmlImporter.FORMAT).createNodes(getResourceAsStream("news.xml"),
                     "/content/documents/mychannel/news", "hippostd:folder");
             recalculateHippoPaths();
             setSiteContentBase("/content/documents/mychannel");

--- a/src/test/java/nl/openweb/hippo/mock/MockHstLinkCreatorTest.java
+++ b/src/test/java/nl/openweb/hippo/mock/MockHstLinkCreatorTest.java
@@ -20,6 +20,7 @@ import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 import java.util.List;
 
+import nl.openweb.jcr.importer.XmlImporter;
 import org.hippoecm.hst.configuration.sitemap.HstSiteMapItem;
 import org.hippoecm.hst.content.beans.standard.HippoBean;
 import org.hippoecm.hst.core.linking.HstLink;
@@ -44,7 +45,7 @@ public class MockHstLinkCreatorTest extends BaseHippoTest {
     @Before
     public void setup() {
         super.setup();
-        importer.createNodesFromXml(getResourceAsStream("/nl/openweb/hippo/demo/news.xml"),
+        getImporter(XmlImporter.FORMAT).createNodes(getResourceAsStream("/nl/openweb/hippo/demo/news.xml"),
                 "/content/documents/mychannel/news", "hippostd:folder");
 
     }


### PR DESCRIPTION
Used the 1.4 version of the jcr-mocking-tool to support YAML files for importing nodes. (See that pull request)