### PR TITLE
Replace static initializer

### DIFF
--- a/src/main/java/nl/openweb/hippo/SimpleHippoTest.java
+++ b/src/main/java/nl/openweb/hippo/SimpleHippoTest.java
@@ -70,7 +70,7 @@ public class SimpleHippoTest {
         }
     };
 
-    static {
+    public SimpleHippoTest() {
         HstServices.setComponentManager(delegatingComponentManager);
     }
 


### PR DESCRIPTION
Other unittests that do not use the hippo-unit-tester might also set a componentmanager on HstServices. Because a static initializer is used this will break the unittests. By setting in the constructor each instance sets the componentmanager and there is no interference of other unittests.